### PR TITLE
Use new addModule syntax

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1,8 +1,7 @@
 const std = @import("std");
 
 pub fn build(b: *std.Build) void {
-    b.addModule(.{
-        .name = "diffz",
+    _ = b.addModule("diffz", .{
         .source_file = .{ .path = "DiffMatchPatch.zig" },
     });
 }


### PR DESCRIPTION
After [this PR](https://github.com/ziglang/zig/pull/14785) the `addModule` function has slightly different arguments and returns the created module. This PR fixes the `build.zig` so it compiles with the new change.

