### PR TITLE
Fixed compatibility with latest builds of Zig

### DIFF
--- a/DiffMatchPatch.zig
+++ b/DiffMatchPatch.zig
@@ -132,7 +132,7 @@ fn diffInternal(
 }
 
 fn diffCommonPrefix(before: []const u8, after: []const u8) usize {
-    const n = std.math.min(before.len, after.len);
+    const n = @min(before.len, after.len);
     var i: usize = 0;
 
     while (i < n) : (i += 1) {
@@ -145,7 +145,7 @@ fn diffCommonPrefix(before: []const u8, after: []const u8) usize {
 }
 
 fn diffCommonSuffix(before: []const u8, after: []const u8) usize {
-    const n = std.math.min(before.len, after.len);
+    const n = @min(before.len, after.len);
     var i: usize = 1;
 
     while (i <= n) : (i += 1) {
@@ -950,8 +950,8 @@ fn diffCleanupSemantic(allocator: std.mem.Allocator, diffs: *DiffList) DiffError
             // Eliminate an equality that is smaller or equal to the edits on both
             // sides of it.
             if (last_equality != null and
-                (last_equality.?.len <= std.math.max(length_insertions1, length_deletions1)) and
-                (last_equality.?.len <= std.math.max(length_insertions2, length_deletions2)))
+                (last_equality.?.len <= @max(length_insertions1, length_deletions1)) and
+                (last_equality.?.len <= @max(length_insertions2, length_deletions2)))
             {
                 // Duplicate record.
                 try diffs.insert(


### PR DESCRIPTION
## Problem
`std.math.min` and `std.math.max` were deprecated with `@compileError` in https://github.com/ziglang/zig/pull/16025 (build number `0.11.0-dev.3663`), and replaced with `@min` and `@max` instead.

## Solution
~~Added compatibility with versions of Zig both before and after that PR with the help of some comptime version checking.~~
Replaced the deprecated calls with `@min` and `@max`. See the comment below.

## Testing
Tested with both the latest git commit of the zig repository, and the latest version on the website, which as of writing this PR were:
Website: `0.11.0-dev.3658`
Latest Commit: `0.11.0-dev.3678` https://github.com/ziglang/zig/commit/f043071cdfb956ff16b1441c9d01ce43eea9fb7b

Both passed all 11 checks.