### PR TITLE
Zig Build System

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
-zig-cache
+zig-*
+.zig-*

--- a/build.zig
+++ b/build.zig
@@ -1,7 +1,33 @@
 const std = @import("std");
 
 pub fn build(b: *std.Build) void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+
     _ = b.addModule("diffz", .{
         .root_source_file = b.path("DiffMatchPatch.zig"),
     });
+
+    const lib = b.addStaticLibrary(.{
+        .name = "diffz",
+        .root_source_file = b.path("DiffMatchPatch.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+
+    // This declares intent for the library to be installed into the standard
+    // location when the user invokes the "install" step (the default step when
+    // running `zig build`).
+    b.installArtifact(lib);
+
+    // Run tests
+    const tests = b.addTest(.{
+        .name = "tests",
+        .root_source_file = b.path("DiffMatchPatch.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    const step_tests = b.addRunArtifact(tests);
+
+    b.step("test", "Run diffz tests").dependOn(&step_tests.step);
 }

--- a/build.zig
+++ b/build.zig
@@ -6,6 +6,8 @@ pub fn build(b: *std.Build) void {
 
     _ = b.addModule("diffz", .{
         .root_source_file = b.path("DiffMatchPatch.zig"),
+        .target = target,
+        .optimize = optimize,
     });
 
     const lib = b.addStaticLibrary(.{

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -3,6 +3,8 @@
     .version = "0.0.1",
     .paths = .{
         "DiffMatchPatch.zig",
+        ".gitattributes",
+        ".gitignore",
         "LICENSE",
         "README.md",
         "build.zig.zon",

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,0 +1,11 @@
+.{
+    .name = "DiffMatchPatch",
+    .version = "0.0.1",
+    .paths = .{
+        "DiffMatchPatch.zig",
+        "LICENSE",
+        "README.md",
+        "build.zig.zon",
+        "build.zig",
+    },
+}

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,5 +1,5 @@
 .{
-    .name = "DiffMatchPatch",
+    .name = "diffz",
     .version = "0.0.1",
     .paths = .{
         "DiffMatchPatch.zig",


### PR DESCRIPTION
This PR updates `diffz` to use a `zig.build.zon` manifest, adds a `zig build test` step, adds `.zig-cache` to the `.gitignore`, and such miscellany. 